### PR TITLE
Fix UI issue of field when used with "whitecube/nova-flexible-conten" 

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -406,6 +406,7 @@ $red500: #ef4444;
     border: none;
     border-radius: 0;
     background: none;
+    display: block;
   }
 
   .multiselect__tags {


### PR DESCRIPTION
This merge request will fix https://github.com/outl1ne/nova-multiselect-field/issues/167 

[
<img width="1791" alt="Screenshot 2022-09-05 at 10 53 33 AM" src="https://user-images.githubusercontent.com/5024250/188366388-2ce06cbb-ba1b-41b4-92bd-3d6ed3460ebf.png">
](url)

