### PR TITLE
Syntax error, unexpected '=>' (T_DOUBLE_ARROW), expecting ')'

### DIFF
--- a/src/Traits/MultiselectBelongsToSupport.php
+++ b/src/Traits/MultiselectBelongsToSupport.php
@@ -119,7 +119,10 @@ trait MultiselectBelongsToSupport
                 'viewable' => $resource ? $resource->authorizedToView(request()) : false,
             ]);
 
-            return $value->map(fn ($model) => $model->{$this->keyName ?? $model->getKeyName()})->toArray();
+            return $value->map(function ($model) {
+                $tempKeyName = $this->keyName ?? $model->getKeyName();
+                return $model->$tempKeyName;
+            })->toArray();
         });
 
         $this->fillUsing(function ($request, $model, $requestAttribute, $attribute) {


### PR DESCRIPTION
I have been using this package for quite a while but I have encountered the following error recently

exception: "ParseError"
file: "/var/www/html/vendor/outl1ne/nova-multiselect-field/src/Traits/MultiselectBelongsToSupport.php"
line: 109
message: "syntax error, unexpected '=>' (T_DOUBLE_ARROW), expecting ')'"
The error seems to be in regard to this line, about to the '{' and '}'

return $value->map(fn ($model) => $model->{$this->keyName ?? $model->getKeyName()})->toArray();
A simple fix to something like this should be enough

return $value->map(function ($model) {
    $tempKeyName = $this->keyName ?? $model->getKeyName();
    return $model->$tempKeyName;
})->toArray();

[Link to the Issue.](https://github.com/outl1ne/nova-multiselect-field/issues/203)
closes #203 