### PR TITLE
Use Param When Filling Form

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -214,17 +214,17 @@ export default {
       }
     },
 
-    fillIfVisible(formData) {
+    fillIfVisible(formData, attribute) {
       if (this.isMultiselect) {
         if (this.value && this.value.length) {
           this.value.forEach((v, i) => {
-            formData.append(`${this.field.attribute}[${i}]`, v.value);
+            formData.append(attribute, v.value);
           });
         } else {
-          formData.append(this.field.attribute, '');
+          formData.append(attribute, '');
         }
       } else {
-        formData.append(this.field.attribute, (this.value && this.value.value) || '');
+        formData.append(attribute, (this.value && this.value.value) || '');
       }
     },
 


### PR DESCRIPTION
Nova passes in the `attribute` name to be used when filling in the form field. Use this instead of the local attribute name